### PR TITLE
Prevent json parsing errors from failing silently

### DIFF
--- a/lib/dir_scanner.js
+++ b/lib/dir_scanner.js
@@ -15,7 +15,7 @@ function readFile(filename, vars) {
     const items = JSON.parse(newContent);
     return items;
   } catch (error) {
-    return {};
+    throw new Error(`couldn't parse package.json at '${filename}': ${parseError.message}`);
   }
 }
 

--- a/lib/dir_scanner.js
+++ b/lib/dir_scanner.js
@@ -15,7 +15,7 @@ function readFile(filename, vars) {
     const items = JSON.parse(newContent);
     return items;
   } catch (error) {
-    throw new Error(`couldn't parse package.json at '${filename}': ${parseError.message}`);
+    throw new Error(`couldn't parse JSON-file at '${filename}': ${error.message}`);
   }
 }
 


### PR DESCRIPTION
Closes #16 

When parsing a config file fails, the error is no longer swallowed, but rethrown with additional information as to which file caused the error. 