### PR TITLE
Remove deasync

### DIFF
--- a/lib/ref_resolver.js
+++ b/lib/ref_resolver.js
@@ -1,13 +1,6 @@
 'use strict';
 
-const deasync = require('deasync');
-const parser = require('json-schema-deref');
-
-function resolveAsync(schema, callback) {
-  parser(schema, (error, resolvedSchema) => {
-    callback(error, resolvedSchema);
-  });
-}
+const parser = require('json-schema-deref-sync');
 
 /**
  * Make the json schema deref parse work sync to support
@@ -21,9 +14,7 @@ function resolveAsync(schema, callback) {
  */
 function refResolver(schema) {
 
-  const resolveSync = deasync(resolveAsync);
-
-  const resolvedSchema = resolveSync(schema);
+  const resolvedSchema = parser(schema);
 
   return resolvedSchema;
 }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,8 @@
     "lib/"
   ],
   "dependencies": {
-    "deasync": "^0.1.8",
     "handlebars": "^4.0.6",
-    "json-schema-deref": "^0.3.5",
+    "json-schema-deref-sync": "^0.5.0",
     "nconf": "^0.8.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I changed the dependency on `json-schema-deref` to `json-schema-deref-sync` to get rid of dependency `deasync`, because it requires native bindings.

Since the API `nconf` offers is synchronous anyway, this will not affect the way we are using the package. 